### PR TITLE
add_token: add flags with properties to use when creating tokens

### DIFF
--- a/kci
+++ b/kci
@@ -81,8 +81,11 @@ cmd_list_labs.description = kci_admin.lab.description_get_list
 def cmd_add_token(args):
     parser = kci_admin.token.parser_create()
     args = parser.parse_args(args)
-    opts = {o: getattr(args, o) for o in
-            ['username', 'email']}
+    opts = {o: getattr(args, o) for o in ['username', 'email']}
+    for prop in ['admin', 'superuser', 'get', 'post', 'delete',
+                 'new_tokens', 'upload']:
+        if getattr(args, prop):
+            opts[prop] = True
     req = kci_admin.token.request_create(args.host, opts)
     post_if_not_dry(args.dry, *req)
 cmd_add_token.description = kci_admin.token.description_create

--- a/kci_admin/token.py
+++ b/kci_admin/token.py
@@ -30,6 +30,20 @@ def parser_create(descr=description_create):
                         help="Username of the user")
     parser.add_argument('--email', required=True,
                         help="email address of the user")
+    parser.add_argument('--admin', action='store_true',
+                        help="enable admin permission")
+    parser.add_argument('--superuser', action='store_true',
+                        help="enable superuser permission")
+    parser.add_argument('--get', action='store_true',
+                        help="enable GET permission")
+    parser.add_argument('--post', action='store_true',
+                        help="enable POST permission")
+    parser.add_argument('--delete', action='store_true',
+                        help="enable DELETE permission")
+    parser.add_argument('--new-tokens', action='store_true',
+                        help="enable permission to create new tokens")
+    parser.add_argument('--upload', action='store_true',
+                        help="enable upload permission")
     return parser
 
 
@@ -40,8 +54,7 @@ def parser_list(descr=description_get_list):
     return parser
 
 
-def request_create(hostname, opts):
-    payload = {k: opts[k] for k in ['username', 'email']}
+def request_create(hostname, payload):
     return kci_request(hostname, "/token", payload)
 
 


### PR DESCRIPTION
Tokens can be created with various properties to give permission to do
HTTP GET, POST, PUT or upload files, have admin permissions etc...
Add a series of command line flags to enable such permissions when
creating a token with the add_token command.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>