### PR TITLE
Added remove_lab and remove_token commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,17 @@ these commands when simply running `kci`:
 Usage:
   kci COMMAND <OPTIONS>
 
+To get command-specific command help:
+
+  kci COMMAND --help
+
 Available commands:
   add_lab          Create a lab entry
-  add_token        Create a user API token
   list_labs        List all the existing labs
+  remove_lab       Remove lab entry
+  add_token        Create a user API token
   list_tokens      List all the existing tokens
+  remove_token     Remove user API token
 ```
 
 Each command will also require some options.  Typically, commands need at least

--- a/kci
+++ b/kci
@@ -78,6 +78,13 @@ def cmd_list_labs(args):
 cmd_list_labs.description = kci_admin.lab.description_get_list
 
 
+def cmd_remove_lab(args):
+    parser = kci_admin.lab.parser_remove()
+    args = parser.parse_args(args)
+    kci_admin.lab.request_remove(args.host, args.id)
+cmd_remove_lab.description = kci_admin.lab.description_remove
+
+
 def cmd_add_token(args):
     parser = kci_admin.token.parser_create()
     args = parser.parse_args(args)

--- a/kci
+++ b/kci
@@ -105,6 +105,13 @@ def cmd_list_tokens(args):
 cmd_list_tokens.description = kci_admin.token.description_get_list
 
 
+def cmd_remove_token(args):
+    parser = kci_admin.token.parser_remove()
+    args = parser.parse_args(args)
+    kci_admin.token.request_remove(args.host, args.id)
+cmd_remove_token.description = kci_admin.token.description_remove
+
+
 def main(argv):
     cmds = {}
     for name, obj in globals().items():

--- a/kci_admin/__init__.py
+++ b/kci_admin/__init__.py
@@ -52,3 +52,9 @@ def request_get(hostname, path):
     response.raise_for_status()
     data = json.loads(response.content.decode('utf8'))
     return data
+
+
+def request_delete(hostname, path):
+    url, headers, _ = request(hostname, path)
+    response = requests.delete(url, headers=headers)
+    response.raise_for_status()

--- a/kci_admin/lab.py
+++ b/kci_admin/lab.py
@@ -17,12 +17,14 @@
 
 from . import request as kci_request
 from . import request_get as kci_request_get
+from . import request_delete as kci_request_delete
 from . import parser as kci_parser
 from . import token
 
 
 description_create = "Create a lab entry"
 description_get_list = "List all the existing labs"
+description_remove = "Remove lab entry"
 
 
 def parser_create(descr=description_create):
@@ -42,6 +44,13 @@ def parser_list(descr=description_get_list):
     parser = kci_parser(descr)
     parser.add_argument('--lab-name',
                         help="Only show details for this given lab")
+    return parser
+
+
+def parser_remove(descr=description_remove):
+    parser = kci_parser(descr)
+    parser.add_argument('--id', metavar='ID', required=True,
+                        help='ObjectId (_id) of the lab to remove')
     return parser
 
 
@@ -78,3 +87,7 @@ def get_list(hostname):
         token_id = lab['token']['$oid']
         lab['token'] = tokens[token_id]['token']
     return data['result']
+
+
+def request_remove(hostname, id_):
+    return kci_request_delete(hostname, "/lab/{}".format(id_))

--- a/kci_admin/token.py
+++ b/kci_admin/token.py
@@ -17,11 +17,13 @@
 
 from . import request as kci_request
 from . import request_get as kci_request_get
+from . import  request_delete as kci_request_delete
 from . import parser as kci_parser
 
 
 description_create = "Create a user API token"
 description_get_list = "List all the existing tokens"
+description_remove = "Remove user API token"
 
 
 def parser_create(descr=description_create):
@@ -54,8 +56,19 @@ def parser_list(descr=description_get_list):
     return parser
 
 
+def parser_remove(descr=description_remove):
+    parser = kci_parser(descr)
+    parser.add_argument('--id', metavar='ID', required=True,
+                        help='ObjectId (_id) of the token to remove')
+    return parser
+
+
 def request_create(hostname, payload):
     return kci_request(hostname, "/token", payload)
+
+
+def request_remove(hostname, id_):
+    return kci_request_delete(hostname,'/token/{}'.format(id_))
 
 
 def get_list(hostname):


### PR DESCRIPTION
Added commands to remove tokens and labs from kernelci-backend.
The commands utilise /lab and /token delete handlers from the backend. 

remove_token command doesn't provide any extra checks apart from what's been implemented in the backend, therefore it's possible to e.g. remove a lab token without any notice.